### PR TITLE
Expo plugin: `onNewIntent` Method Conflict in Android MainActivity

### DIFF
--- a/src/plugin/withPaypalWebPayments.ts
+++ b/src/plugin/withPaypalWebPayments.ts
@@ -11,9 +11,9 @@ export const setOnNewIntent = (mainActivity: string) => {
   }
   let result = mainActivity;
   const methodCode = `
-  override fun onNewIntent(newIntent: Intent) {
-      super.onNewIntent(newIntent)
-      intent = newIntent
+  override fun onNewIntent(intent: Intent) {
+      super.onNewIntent(intent)
+      this.intent = intent
   }`;
 
   // Ensure the necessary import is present


### PR DESCRIPTION
I've encountered a compatibility issue when using this package alongside other libraries that also need to handle new intents in the Android MainActivity.

I would like to suggest  a use of a [default](https://developer.android.com/reference/kotlin/android/app/Activity#onNewIntent(android.content.Intent)) signature of kotlin method.

---

For a more robust long-term solution, I suggest modifying the Expo plugin to perform a "soft" modification.:

1. Check for an existing `onNewIntent` implementation in `MainActivity.kt`.
2. If it exists, inject the necessary PayPal-specific code inside the body of the existing method, preferably after a call to super.onNewIntent(intent).
3. If it doesn't exist, inject the full override fun onNewIntent(intent: Intent) { ... } method