### PR TITLE
fix compiling on react native 0.81+

### DIFF
--- a/android/src/main/java/com/paypalwebpayments/PaypalWebPaymentsModule.kt
+++ b/android/src/main/java/com/paypalwebpayments/PaypalWebPaymentsModule.kt
@@ -36,14 +36,14 @@ class PaypalWebPaymentsModule internal constructor(context: ReactApplicationCont
     onEvent: Callback?
   ) {
 
-    currentActivity!!.runOnUiThread {
+    reactApplicationContext.currentActivity!!.runOnUiThread {
       val config = CoreConfig(
         clientID,
         environment.toEnvironment()
       )
 
       val payPalWebCheckoutClient = PayPalWebCheckoutClient(
-        currentActivity as FragmentActivity,
+        reactApplicationContext.currentActivity as FragmentActivity,
         config,
         urlScheme
       )


### PR DESCRIPTION
Fixes the Function invocation 'getCurrentActivity()' expected error when compiling on React Native 0.81+